### PR TITLE
added hybrid-sync-transport

### DIFF
--- a/pkg/bundle/delta_compliance_status_bundle.go
+++ b/pkg/bundle/delta_compliance_status_bundle.go
@@ -300,9 +300,23 @@ func (bundle *DeltaComplianceStatusBundle) getExistingPolicyState(policyIndex in
 }
 
 func (bundle *DeltaComplianceStatusBundle) syncGenericStatus(status *statusbundle.PolicyGenericComplianceStatus) {
-	bundle.complianceRecordsCache[status.PolicyID] = &policyComplianceStatus{
-		compliantClustersSet:    set.NewSet(status.CompliantClusters),
-		nonCompliantClustersSet: set.NewSet(status.NonCompliantClusters),
-		unknownClustersSet:      set.NewSet(status.UnknownComplianceClusters),
+	policyComplianceStatus := &policyComplianceStatus{
+		compliantClustersSet:    set.NewSet(),
+		nonCompliantClustersSet: set.NewSet(),
+		unknownClustersSet:      set.NewSet(),
 	}
+
+	for _, cluster := range status.CompliantClusters {
+		policyComplianceStatus.compliantClustersSet.Add(cluster)
+	}
+
+	for _, cluster := range status.NonCompliantClusters {
+		policyComplianceStatus.nonCompliantClustersSet.Add(cluster)
+	}
+
+	for _, cluster := range status.UnknownComplianceClusters {
+		policyComplianceStatus.unknownClustersSet.Add(cluster)
+	}
+
+	bundle.complianceRecordsCache[status.PolicyID] = policyComplianceStatus
 }

--- a/pkg/transport/hybrid_sync_transport.go
+++ b/pkg/transport/hybrid_sync_transport.go
@@ -1,0 +1,16 @@
+package transport
+
+// HybridSyncTransport is an extension of Transport that supports hybrid-sync mode (complete-state + delta-state sync).
+type HybridSyncTransport interface {
+	Transport
+	// RegisterDeltaMessagePrefix registers a bundle type (delta-bundle) with a key prefix that should change per delta-
+	// bundle to control the message-compaction if supported and enabled and avoid losing delta bundles.
+	//
+	// IMPORTANT:
+	//
+	// 1) this implies that when using this functionality, it must be fine that the reader (consumer) can lose
+	// delta-messages due to compaction if the prefix resets.
+	//
+	// 2) the given prefix must be safe to read by the transport, alter in transport callbacks only.
+	RegisterDeltaMessagePrefix(msgID string, prefix *int)
+}

--- a/pkg/transport/sync-service/sync_service.go
+++ b/pkg/transport/sync-service/sync_service.go
@@ -104,11 +104,6 @@ func (s *SyncService) Subscribe(messageID string, callbacks map[transport.EventT
 	s.eventSubscriptionMap[messageID] = callbacks
 }
 
-// SupportsDeltaBundles returns false. sync service doesn't support delta bundles.
-func (s *SyncService) SupportsDeltaBundles() bool {
-	return false
-}
-
 // SendAsync function sends a message to the sync service asynchronously.
 func (s *SyncService) SendAsync(message *transport.Message) {
 	s.msgChan <- message

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -25,6 +25,4 @@ type Transport interface {
 	Start()
 	// Stop stops the transport.
 	Stop()
-	// SupportsDeltaBundles returns true if the transport layer supports delta bundles, otherwise false.
-	SupportsDeltaBundles() bool
 }


### PR DESCRIPTION
added hybrid sync transport interface as an extension to the transport interface, with functionality to assign a dynamic prefix to delta bundles.

+ minor modification to compliance delta bundle