### PR TITLE
separation of bundle-id and msg-transport-key

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -21,6 +21,8 @@ type Object interface {
 
 // Bundle is an abstraction for managing different bundle types.
 type Bundle interface {
+	// GetID function to get bundle ID (data-type), used to identify the bundle.
+	GetID() string
 	// UpdateObject function to update a single object inside a bundle.
 	UpdateObject(object Object)
 	// DeleteObject function to delete a single object inside a bundle.

--- a/pkg/bundle/clusters_per_policy_bundle.go
+++ b/pkg/bundle/clusters_per_policy_bundle.go
@@ -4,8 +4,11 @@ import (
 	"sync"
 
 	policiesv1 "github.com/open-cluster-management/governance-policy-propagator/pkg/apis/policy/v1"
+	datatypes "github.com/open-cluster-management/hub-of-hubs-data-types"
 	statusbundle "github.com/open-cluster-management/hub-of-hubs-data-types/bundle/status"
 )
+
+const clustersPerPolicyBundleID = datatypes.ClustersPerPolicyMsgKey
 
 // NewClustersPerPolicyBundle creates a new instance of ClustersPerPolicyBundle.
 func NewClustersPerPolicyBundle(leafHubName string, incarnation uint64,
@@ -26,6 +29,11 @@ type ClustersPerPolicyBundle struct {
 	statusbundle.BaseClustersPerPolicyBundle
 	extractObjIDFunc ExtractObjIDFunc
 	lock             sync.Mutex
+}
+
+// GetID returns type identifier for this bundle.
+func (bundle *ClustersPerPolicyBundle) GetID() string {
+	return clustersPerPolicyBundleID
 }
 
 // UpdateObject function to update a single object inside a bundle.

--- a/pkg/bundle/complete_compliance_status_bundle.go
+++ b/pkg/bundle/complete_compliance_status_bundle.go
@@ -4,8 +4,11 @@ import (
 	"sync"
 
 	policyv1 "github.com/open-cluster-management/governance-policy-propagator/pkg/apis/policy/v1"
+	datatypes "github.com/open-cluster-management/hub-of-hubs-data-types"
 	statusbundle "github.com/open-cluster-management/hub-of-hubs-data-types/bundle/status"
 )
+
+const completeComplianceStatusBundleID = datatypes.PolicyCompleteComplianceMsgKey
 
 // NewCompleteComplianceStatusBundle creates a new instance of ComplianceStatusBundle.
 func NewCompleteComplianceStatusBundle(leafHubName string, baseBundle Bundle, incarnation uint64,
@@ -29,6 +32,11 @@ type ComplianceStatusBundle struct {
 	baseBundle       Bundle
 	extractObjIDFunc ExtractObjIDFunc
 	lock             sync.Mutex
+}
+
+// GetID returns type identifier for this bundle.
+func (bundle *ComplianceStatusBundle) GetID() string {
+	return completeComplianceStatusBundleID
 }
 
 // UpdateObject function to update a single object inside a bundle.

--- a/pkg/bundle/control_info_bundle.go
+++ b/pkg/bundle/control_info_bundle.go
@@ -3,8 +3,11 @@ package bundle
 import (
 	"sync"
 
+	datatypes "github.com/open-cluster-management/hub-of-hubs-data-types"
 	statusbundle "github.com/open-cluster-management/hub-of-hubs-data-types/bundle/status"
 )
+
+const controlInfoBundleID = datatypes.ControlInfoMsgKey
 
 // NewControlInfoBundle creates a new instance of ControlInfoBundle.
 func NewControlInfoBundle(leafHubName string, incarnation uint64) *ControlInfoBundle {
@@ -20,6 +23,11 @@ type ControlInfoBundle struct {
 	LeafHubName   string                      `json:"leafHubName"`
 	BundleVersion *statusbundle.BundleVersion `json:"bundleVersion"`
 	lock          sync.Mutex
+}
+
+// GetID returns type identifier for this bundle.
+func (bundle *ControlInfoBundle) GetID() string {
+	return controlInfoBundleID
 }
 
 // UpdateObject function to update a single object inside a bundle.

--- a/pkg/bundle/delta_compliance_status_bundle.go
+++ b/pkg/bundle/delta_compliance_status_bundle.go
@@ -6,10 +6,14 @@ import (
 
 	set "github.com/deckarep/golang-set"
 	v1 "github.com/open-cluster-management/governance-policy-propagator/pkg/apis/policy/v1"
+	datatypes "github.com/open-cluster-management/hub-of-hubs-data-types"
 	statusbundle "github.com/open-cluster-management/hub-of-hubs-data-types/bundle/status"
 )
 
-const unknownComplianceStatus = "unknown"
+const (
+	deltaComplianceStatusBundleID = datatypes.PolicyDeltaComplianceMsgKey
+	unknownComplianceStatus       = "unknown"
+)
 
 var errPolicyStatusUnchanged = errors.New("policy status did not changed")
 
@@ -48,6 +52,11 @@ type policyComplianceStatus struct {
 	compliantClustersSet    set.Set
 	nonCompliantClustersSet set.Set
 	unknownClustersSet      set.Set
+}
+
+// GetID returns type identifier for this bundle.
+func (bundle *DeltaComplianceStatusBundle) GetID() string {
+	return deltaComplianceStatusBundleID
 }
 
 // UpdateObject function to update a single object inside a bundle.

--- a/pkg/bundle/generic_status_bundle.go
+++ b/pkg/bundle/generic_status_bundle.go
@@ -8,7 +8,8 @@ import (
 )
 
 // NewGenericStatusBundle creates a new instance of GenericStatusBundle.
-func NewGenericStatusBundle(leafHubName string, incarnation uint64, cleanObjFunc func(obj Object)) Bundle {
+func NewGenericStatusBundle(bundleID string, leafHubName string, incarnation uint64,
+	cleanObjFunc func(obj Object)) Bundle {
 	if cleanObjFunc == nil {
 		cleanObjFunc = func(object Object) {}
 	}
@@ -17,6 +18,7 @@ func NewGenericStatusBundle(leafHubName string, incarnation uint64, cleanObjFunc
 		Objects:       make([]Object, 0),
 		LeafHubName:   leafHubName,
 		BundleVersion: statusbundle.NewBundleVersion(incarnation, 0),
+		id:            bundleID,
 		cleanObjFunc:  cleanObjFunc,
 		lock:          sync.Mutex{},
 	}
@@ -29,8 +31,14 @@ type GenericStatusBundle struct {
 	Objects       []Object                    `json:"objects"`
 	LeafHubName   string                      `json:"leafHubName"`
 	BundleVersion *statusbundle.BundleVersion `json:"bundleVersion"`
+	id            string
 	cleanObjFunc  func(obj Object)
 	lock          sync.Mutex
+}
+
+// GetID returns type identifier for this bundle.
+func (bundle *GenericStatusBundle) GetID() string {
+	return bundle.id
 }
 
 // UpdateObject function to update a single object inside a bundle.

--- a/pkg/bundle/minimal_compliance_status_bundle.go
+++ b/pkg/bundle/minimal_compliance_status_bundle.go
@@ -8,6 +8,8 @@ import (
 	statusbundle "github.com/open-cluster-management/hub-of-hubs-data-types/bundle/status"
 )
 
+const minimalComplianceStatusBundleID = datatypes.MinimalPolicyComplianceMsgKey
+
 // NewMinimalComplianceStatusBundle creates a new instance of MinimalComplianceStatusBundle.
 func NewMinimalComplianceStatusBundle(leafHubName string, incarnation uint64) Bundle {
 	return &MinimalComplianceStatusBundle{
@@ -24,6 +26,11 @@ func NewMinimalComplianceStatusBundle(leafHubName string, incarnation uint64) Bu
 type MinimalComplianceStatusBundle struct {
 	statusbundle.BaseMinimalComplianceStatusBundle
 	lock sync.Mutex
+}
+
+// GetID returns type identifier for this bundle.
+func (bundle *MinimalComplianceStatusBundle) GetID() string {
+	return minimalComplianceStatusBundleID
 }
 
 // UpdateObject function to update a single object inside a bundle.

--- a/pkg/controller/generic/generic_status_sync_controller.go
+++ b/pkg/controller/generic/generic_status_sync_controller.go
@@ -201,8 +201,8 @@ func (c *genericStatusSyncController) syncBundles() {
 
 		// send to transport only if bundle has changed.
 		if bundleVersion.NewerThan(&entry.lastSentBundleVersion) {
-			if err := helpers.SyncToTransport(c.transport, entry.transportBundleKey, datatypes.StatusBundle,
-				bundleVersion, entry.bundle); err != nil {
+			if err := helpers.SyncToTransport(c.transport, entry.transportBundleKey, entry.bundle.GetID(),
+				datatypes.StatusBundle, bundleVersion, entry.bundle); err != nil {
 				c.log.Error(err, "failed to sync to transport")
 
 				return // do not update last sent generation in case of failure in sync bundle to transport

--- a/pkg/controller/local_policies/local_placementrules_sync.go
+++ b/pkg/controller/local_policies/local_placementrules_sync.go
@@ -27,11 +27,12 @@ func AddLocalPlacementRulesController(mgr ctrl.Manager, transport transport.Tran
 	incarnation uint64, hubOfHubsConfig *configv1.Config, syncIntervalsData *syncintervals.SyncIntervals) error {
 	createObjFunc := func() bundle.Object { return &placementrulesv1.PlacementRule{} }
 
-	localPlacementRuleTransportKey := fmt.Sprintf("%s.%s", leafHubName, datatypes.LocalPlacementRulesMsgKey)
+	localPlacementRuleBundle := bundle.NewGenericStatusBundle(datatypes.LocalPlacementRulesMsgKey, leafHubName,
+		incarnation, cleanPlacementRuleFunc)
 
 	bundleCollection := []*generic.BundleCollectionEntry{
-		generic.NewBundleCollectionEntry(localPlacementRuleTransportKey,
-			bundle.NewGenericStatusBundle(leafHubName, incarnation, cleanPlacementRuleFunc),
+		generic.NewBundleCollectionEntry(fmt.Sprintf("%s.%s", leafHubName, localPlacementRuleBundle.GetID()),
+			localPlacementRuleBundle,
 			func() bool { // bundle predicate
 				return hubOfHubsConfig.Spec.EnableLocalPolicies
 			}),

--- a/pkg/controller/local_policies/local_policy_sync.go
+++ b/pkg/controller/local_policies/local_policy_sync.go
@@ -48,19 +48,19 @@ func createBundleCollection(leafHubName string, incarnation uint64,
 	extractLocalPolicyIDFunc := func(obj bundle.Object) (string, bool) { return string(obj.GetUID()), true }
 
 	// clusters per policy (base bundle)
-	localClustersPerPolicyTransportKey := fmt.Sprintf("%s.%s", leafHubName,
-		datatypes.LocalClustersPerPolicyMsgKey)
 	localClustersPerPolicyBundle := bundle.NewClustersPerPolicyBundle(leafHubName, incarnation,
 		extractLocalPolicyIDFunc)
+	localClustersPerPolicyTransportKey := fmt.Sprintf("%s.%s", leafHubName, localClustersPerPolicyBundle.GetID())
 
 	// compliance status bundle
-	localCompleteComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName,
-		datatypes.LocalPolicyCompleteComplianceMsgKey)
 	localCompleteComplianceStatusBundle := bundle.NewCompleteComplianceStatusBundle(leafHubName,
 		localClustersPerPolicyBundle, incarnation, extractLocalPolicyIDFunc)
+	localCompleteComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName,
+		localCompleteComplianceStatusBundle.GetID())
 
-	localPolicySpecTransportKey := fmt.Sprintf("%s.%s", leafHubName, datatypes.LocalPolicySpecMsgKey)
-	localPolicySpecBundle := bundle.NewGenericStatusBundle(leafHubName, incarnation, cleanPolicyFunc)
+	localPolicySpecBundle := bundle.NewGenericStatusBundle(datatypes.LocalPolicySpecMsgKey, leafHubName, incarnation,
+		cleanPolicyFunc)
+	localPolicySpecTransportKey := fmt.Sprintf("%s.%s", leafHubName, localPolicySpecBundle.GetID())
 
 	// check for full information
 	localPolicyStatusPredicate := func() bool {

--- a/pkg/controller/managedclusters/clusters_status_sync.go
+++ b/pkg/controller/managedclusters/clusters_status_sync.go
@@ -25,11 +25,12 @@ const (
 func AddClustersStatusController(mgr ctrl.Manager, transport transport.Transport, leafHubName string,
 	incarnation uint64, hubOfHubsConfig *configv1.Config, syncIntervalsData *syncintervals.SyncIntervals) error {
 	createObjFunction := func() bundle.Object { return &clusterv1.ManagedCluster{} }
-	transportBundleKey := fmt.Sprintf("%s.%s", leafHubName, datatypes.ManagedClustersMsgKey)
+	managedClustersBundle := bundle.NewGenericStatusBundle(datatypes.ManagedClustersMsgKey, leafHubName, incarnation,
+		nil)
 
 	bundleCollection := []*generic.BundleCollectionEntry{ // single bundle for managed clusters
-		generic.NewBundleCollectionEntry(transportBundleKey, bundle.NewGenericStatusBundle(leafHubName, incarnation,
-			nil),
+		generic.NewBundleCollectionEntry(fmt.Sprintf("%s.%s", leafHubName, managedClustersBundle.GetID()),
+			managedClustersBundle,
 			func() bool { // bundle predicate
 				return hubOfHubsConfig.Spec.AggregationLevel == configv1.Full ||
 					hubOfHubsConfig.Spec.AggregationLevel == configv1.Minimal

--- a/pkg/controller/policies/policy_status_sync.go
+++ b/pkg/controller/policies/policy_status_sync.go
@@ -70,13 +70,12 @@ func createBundleCollection(transportObj transport.Transport, leafHubName string
 	}
 
 	// clusters per policy (base bundle)
-	clustersPerPolicyTransportKey := fmt.Sprintf("%s.%s", leafHubName, datatypes.ClustersPerPolicyMsgKey)
 	clustersPerPolicyBundle := bundle.NewClustersPerPolicyBundle(leafHubName, incarnation, extractPolicyID)
+	clustersPerPolicyTransportKey := fmt.Sprintf("%s.%s", leafHubName, clustersPerPolicyBundle.GetID())
 
 	// minimal compliance status bundle
-	minimalComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName,
-		datatypes.MinimalPolicyComplianceMsgKey)
 	minimalComplianceStatusBundle := bundle.NewMinimalComplianceStatusBundle(leafHubName, incarnation)
+	minimalComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName, minimalComplianceStatusBundle.GetID())
 
 	fullStatusPredicate := func() bool { return hubOfHubsConfig.Spec.AggregationLevel == configv1.Full }
 	minimalStatusPredicate := func() bool { return hubOfHubsConfig.Spec.AggregationLevel == configv1.Minimal }
@@ -122,14 +121,14 @@ func getHybridComplianceBundleCollectionEntries(transport transport.Transport, l
 	incarnation uint64, fullStatusPredicate func() bool, clustersPerPolicyBundle bundle.Bundle,
 	deltaCountSwitchFactor int) (*generic.BundleCollectionEntry, *generic.BundleCollectionEntry, error) {
 	// complete compliance status bundle
-	completeComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName, datatypes.PolicyCompleteComplianceMsgKey)
 	completeComplianceStatusBundle := bundle.NewCompleteComplianceStatusBundle(leafHubName, clustersPerPolicyBundle,
 		incarnation, extractPolicyID)
+	completeComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName, completeComplianceStatusBundle.GetID())
 
 	// delta compliance status bundle
-	deltaComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName, datatypes.PolicyDeltaComplianceMsgKey)
 	deltaComplianceStatusBundle := bundle.NewDeltaComplianceStatusBundle(leafHubName, completeComplianceStatusBundle,
 		clustersPerPolicyBundle.(*bundle.ClustersPerPolicyBundle), incarnation, extractPolicyID)
+	deltaComplianceStatusTransportKey := fmt.Sprintf("%s.%s", leafHubName, deltaComplianceStatusBundle.GetID())
 
 	completeComplianceBundleCollectionEntry := generic.NewBundleCollectionEntry(completeComplianceStatusTransportKey,
 		completeComplianceStatusBundle, fullStatusPredicate)

--- a/pkg/controller/policies/policy_status_sync.go
+++ b/pkg/controller/policies/policy_status_sync.go
@@ -136,7 +136,7 @@ func getHybridComplianceBundleCollectionEntries(transport transport.Transport, l
 		deltaComplianceStatusBundle, fullStatusPredicate)
 
 	if err := generic.NewHybridSyncManager(ctrl.Log.WithName("compliance-status hybrid sync manager"),
-		transport, completeComplianceBundleCollectionEntry, deltaComplianceBundleCollectionEntry,
+		transport, leafHubName, completeComplianceBundleCollectionEntry, deltaComplianceBundleCollectionEntry,
 		deltaCountSwitchFactor); err != nil {
 		return nil, nil, fmt.Errorf("%w: %v", err, errFailedToCreateHybridSyncManager)
 	}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -38,19 +38,20 @@ func HasLabel(obj metav1.Object, label string) bool {
 }
 
 // SyncToTransport syncs the provided bundle to transport.
-func SyncToTransport(transportObj transport.Transport, msgID string, msgType string, version fmt.Stringer,
-	payload bundle.Bundle) error {
+func SyncToTransport(transportObj transport.Transport, transportMsgKey string, msgID string, msgType string,
+	version fmt.Stringer, payload bundle.Bundle) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to sync object from type %s with id %s - %w", msgType, msgID, err)
 	}
 
-	transportObj.SendAsync(&transport.Message{
-		ID:      msgID,
-		MsgType: msgType,
-		Version: version.String(),
-		Payload: payloadBytes,
-	})
+	transportObj.SendAsync(transportMsgKey,
+		&transport.Message{
+			ID:      msgID,
+			MsgType: msgType,
+			Version: version.String(),
+			Payload: payloadBytes,
+		})
 
 	return nil
 }

--- a/pkg/transport/kafka/producer.go
+++ b/pkg/transport/kafka/producer.go
@@ -198,7 +198,7 @@ func (p *Producer) SupportsDeltaBundles() bool {
 }
 
 // SendAsync sends a message to the sync service asynchronously.
-func (p *Producer) SendAsync(message *transport.Message) {
+func (p *Producer) SendAsync(key string, message *transport.Message) {
 	messageBytes, err := json.Marshal(message)
 	if err != nil {
 		p.log.Error(err, "failed to send message", "MessageId", message.ID, "MessageType",
@@ -221,7 +221,7 @@ func (p *Producer) SendAsync(message *transport.Message) {
 		{Key: kafkaHeaderTypes.HeaderCompressionType, Value: []byte(p.compressor.GetType())},
 	}
 
-	if err = p.kafkaProducer.ProduceAsync(message.ID, p.topic, partition, headers, compressedBytes); err != nil {
+	if err = p.kafkaProducer.ProduceAsync(key, p.topic, partition, headers, compressedBytes); err != nil {
 		p.log.Error(err, "failed to send message", "MessageId", message.ID, "MessageType",
 			message.MsgType, "Version", message.Version)
 		transport.InvokeCallback(p.eventSubscriptionMap, message.ID, transport.DeliveryFailure)

--- a/pkg/transport/sync-service/sync_service.go
+++ b/pkg/transport/sync-service/sync_service.go
@@ -110,7 +110,7 @@ func (s *SyncService) SupportsDeltaBundles() bool {
 }
 
 // SendAsync function sends a message to the sync service asynchronously.
-func (s *SyncService) SendAsync(message *transport.Message) {
+func (s *SyncService) SendAsync(_ string, message *transport.Message) {
 	s.msgChan <- message
 }
 

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -18,7 +18,7 @@ const (
 // Transport is the transport layer interface to be consumed by the leaf hub status sync.
 type Transport interface {
 	// SendAsync sends a message to the transport component asynchronously.
-	SendAsync(message *Message)
+	SendAsync(key string, message *Message)
 	// Subscribe adds a callback to be delegated when a given event occurs for a message with the given ID.
 	Subscribe(messageID string, callbacks map[EventType]EventCallback)
 	// Start starts the transport.


### PR DESCRIPTION
added bundle.GetID function to better separate between a bundle identifier and a bundle entry's transportation key.